### PR TITLE
Use `<icon-instance>.element`, never use `LabIcon.resolveElement`

### DIFF
--- a/src/unfold.ts
+++ b/src/unfold.ts
@@ -151,8 +151,7 @@ export class FileTreeRenderer extends DirListing.Renderer {
         'jp-DirListing-itemIcon'
       );
 
-      LabIcon.resolveElement({
-        icon: folderOpenIcon,
+      folderOpenIcon.element({
         iconClass: classes('jp-Icon'),
         container: iconContainer,
         className: 'jp-DirListing-itemIcon',


### PR DESCRIPTION
Honestly, I think the `LabIcon.resolveX` static methods might be the single biggest mistake I've made as a jlab developer. I at least should have named them

```
LabIcon.__XXX___DO_NOT_TOUCH__PRETTY_PLEASE_resolveX`
```

Less dramatically, the `.ResolveX` methods exist to cover an edge case that occurs in several places in core where instead of a full `LabIcon` instace all you may have instead is just the icon's name string. Your usage of `.resolveElement` probably isn't actively harmful here, but it is an anti-pattern. It's very slow, and (in my opinion) harder to read, in comparison to the standard `<icon-instance>.element` invocation I changed it to