### PR TITLE
Unpin alpha-10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     install_requires=[
         "jupyter_server>=1.6,<2",
-        "jupyterlab==3.1.0-alpha.10"
+        "jupyterlab>=3.1.0-alpha.10"
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
I wanted to include it in my binder but it annoys the pip resolver as I was trying to use beta version. Would it be a good idea to use `>=` instead?