### PR TITLE
Put back default behavior for single click

### DIFF
--- a/schema/jupyterlab-unfold-settings.json
+++ b/schema/jupyterlab-unfold-settings.json
@@ -7,7 +7,7 @@
         "type": "boolean",
         "title": "Single Click To Unfold",
         "description": "Whether a single click triggers an (un)fold.",
-        "default": false
+        "default": true
       }
     }
 }

--- a/src/unfold.ts
+++ b/src/unfold.ts
@@ -395,7 +395,7 @@ export class DirTreeListing extends DirListing {
     }
   }
 
-  private _singleClickToUnfold = false;
+  private _singleClickToUnfold = true;
 }
 
 /**


### PR DESCRIPTION
This puts back the default behavior for single-slick so that users only get the double-click to unfold if they want.